### PR TITLE
Make Sapper not reload

### DIFF
--- a/src/components/icon-button/Link.svelte
+++ b/src/components/icon-button/Link.svelte
@@ -12,7 +12,7 @@
 </style>
 
 {#if href}
-	<a {href} target={newTab ? '_blank' : '_self'}>
+	<a {href} target={newTab ? '_blank' : null}>
 		<slot />
 	</a>
 {:else}


### PR DESCRIPTION
`target="_self"` appears to make Sapper reload.  Removing this fixes the problem.

Fixes #106 

<!--
Thanks for creating a pull request.

If your PR contains a new feature or component, please open an issue to discuss it first.

(Don't forget to `npm run lint`!)
-->
